### PR TITLE
build job update

### DIFF
--- a/.github/workflows/retype.yml
+++ b/.github/workflows/retype.yml
@@ -1,9 +1,6 @@
 name: Publish Retype powered website to GitHub Pages
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
 
 jobs:
   publish:


### PR DESCRIPTION
- we no longer want to deploy built documentation immediately, removed PUSH trigger
- action will be triggered by API, when LTS version of UC is built