### PR TITLE
Removed 'reconcile' mountpoint parameter

### DIFF
--- a/frinx-uniconfig/user-guide/network-management-protocols/uniconfig-installing/readme.md
+++ b/frinx-uniconfig/user-guide/network-management-protocols/uniconfig-installing/readme.md
@@ -370,7 +370,6 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
             "cli-topology:journal-size": 150,
             "cli-topology:dry-run-journal-size": 150,
             "cli-topology:parsing-engine": "batch-parser",
-            "node-extension:reconcile": false,
             "uniconfig-config:install-uniconfig-node-enabled": false
         }
     }

--- a/frinx-uniconfig/user-guide/network-management-protocols/uniconfig-native_cli/readme.md
+++ b/frinx-uniconfig/user-guide/network-management-protocols/uniconfig-native_cli/readme.md
@@ -55,7 +55,6 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
             "cli-topology:journal-size": 150,
             "cli-topology:dry-run-journal-size": 150,
             "cli-topology:parsing-engine": "batch-parser",
-            "node-extension:reconcile": false,
             "uniconfig-config:install-uniconfig-node-enabled": false,
             "uniconfig-config:uniconfig-native-enabled": true
         }

--- a/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_cli/readme.md
+++ b/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_cli/readme.md
@@ -100,7 +100,7 @@ that actually
 The plugin itself is responsible for defining the mapping between YANG
 and CLI. However, the translation layer into which it plugs in is what
 handles the heavy lifting for it e.g. transactions, rollback, config
-data storage, reconciliation etc. Additionally, the SPIs of the
+data storage etc. Additionally, the SPIs of the
 translation layer are very simple to implement because the translation
 plugin only needs to focus on the translations between YANG \<-\ CLI.
 
@@ -177,29 +177,6 @@ CLI southbound plugin:
 
 - **RPCs** stand on their own and can encapsulate any command(s) on
     the device.
-
-## Reconciliation
-
-There might be situations where there are inconsistencies between actual
-configuration on the device and the state cached in Frinx UniConfig.
-That's why a reconciliation mechanism was developed to:
-
--   Allows the mountpoint to sync its state when first connecting to the
-    device.
--   Allows apps/users to request synchronization when an inconsistent
-    state is expected e.g. manual configuration of the device.
-
-Reconciliation is performed when issuing any READ operation. If the data
-coming from device is different compared to mountpoint cache, the cache
-will be updated automatically.
-
-Initial reconciliation (after connection has been established) takes
-place automatically on the CLI layer. However it can be disabled with
-attribute "node-extension:reconcile" set to false when installing a
-device. Uniconfig performs its own reconciliation when devices are
-connected so if both the Uniconfig and CLI layer reconcile, the install
-process is unnecessarily prolonged. That's why it is advised to turn off
-reconciliation on the CLI layer when using Uniconfig.
 
 ## RPCs provided by CLI layer
 

--- a/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_mounting/mounting-process.rst
+++ b/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_mounting/mounting-process.rst
@@ -93,7 +93,6 @@ Other non-mandatory parameters that can be added to mount-request.
 * **cli-topology:error-commit-patterns** - Device specific list of commit error patterns. The following list of patterns is checked in the input after 'commit' command is sent.
 * **cli-topology:error-patterns** - Device specific list of error patterns. This list is the primary source of error checking on the device. The list defined by this parameter can override hardcoded one specified in the code.
 * **cli-topology:parsing-engine** - Specification of the parsing system that is responsible for interpretation of device running-configuration. For now, supported methods are 'tree-parser' (default option) and 'batch-parser'.
-* **node-extension:reconcile** - Whether to invoke reconciliation upon connection to a device.
 
 .. note::
 
@@ -124,8 +123,7 @@ Mounting of IOS-XR device (version 6.3.4) on address '192.168.1.211' with enable
                 "cli-topology:username": "cisco",
                 "cli-topology:password": "cisco",
                 "cli-topology:journal-size": 150,
-                "cli-topology:dry-run-journal-size": 200,
-                "node-extension:reconcile": false
+                "cli-topology:dry-run-journal-size": 200
             }
         }'
 
@@ -433,7 +431,7 @@ For mounting of NETCONF device with uniconfig-native support, it is necessary to
 Example - mounting of uniconfig-native CLI device
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For mounting of CLI device with uniconfig-native support, it is necessary to explicitly enable this functionality using 'uniconfig-native-enabled' flag. The following example shows request used for mounting of JUNOS 17.3 device as native-CLI device with enabled dry-run functionality and disabled reconciliation.
+For mounting of CLI device with uniconfig-native support, it is necessary to explicitly enable this functionality using 'uniconfig-native-enabled' flag. The following example shows request used for mounting of JUNOS 17.3 device as native-CLI device with enabled dry-run functionality.
 
 .. code:: bash
 
@@ -451,7 +449,6 @@ For mounting of CLI device with uniconfig-native support, it is necessary to exp
             "cli-topology:password": "junos17pass",
             "cli-topology:journal-size": 150,
             "cli-topology:dry-run-journal-size": 180,
-            "node-extension:reconcile": false,
             "uniconfig-config:uniconfig-native-enabled": true
         }
     }'

--- a/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_mounting/mounting-process.rst
+++ b/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_mounting/mounting-process.rst
@@ -431,7 +431,7 @@ For mounting of NETCONF device with uniconfig-native support, it is necessary to
 Example - mounting of uniconfig-native CLI device
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For mounting of CLI device with uniconfig-native support, it is necessary to explicitly enable this functionality using 'uniconfig-native-enabled' flag. The following example shows request used for mounting of JUNOS 17.3 device as native-CLI device with enabled dry-run functionality.
+To mount a CLI device with uniconfig-native support, you must explicitly enable this functionality using the 'uniconfig-native-enabled' flag. The following example shows a request used to mount a JUNOS 17.3 device as a native-CLI device with dry-run functionality enabled.
 
 .. code:: bash
 

--- a/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_netconf/ocnos.md
+++ b/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_netconf/ocnos.md
@@ -14,7 +14,6 @@ curl PUT \
       {
         "node-id": "ocnos",
         "netconf-node-topology:host": "192.168.1.248",
-        "node-extension:reconcile": false,
         "netconf-node-topology:session-timers" : {
           "netconf-node-topology:keepalive-delay": 10,
           "netconf-node-topology:reconnection-attempts-multiplier": 1,

--- a/frinx-uniconfig/user-guide/network-management-protocols/updating-installation-parameters/readme.md
+++ b/frinx-uniconfig/user-guide/network-management-protocols/updating-installation-parameters/readme.md
@@ -32,7 +32,6 @@ Output:
     "node": [
         {
             "node-id": "cliNode",
-            "node-extension:reconcile": false,
             "uniconfig-config:install-uniconfig-node-enabled": true,
             "cli-topology:host": "192.168.1.225",
             "cli-topology:transport-type": "ssh",
@@ -104,7 +103,6 @@ curl -X PUT \
      "node": [
         {
             "node-id": "cliNode",
-            "node-extension:reconcile": false,
             "uniconfig-config:install-uniconfig-node-enabled": true,
             "cli-topology:host": "192.168.1.230",
             "cli-topology:transport-type": "ssh",

--- a/frinx-uniconfig/user-guide/uniconfig-operations/uniconfig-node-manager/uniconfig_install_multiple_nodes/readme.md
+++ b/frinx-uniconfig/user-guide/uniconfig-operations/uniconfig-node-manager/uniconfig_install_multiple_nodes/readme.md
@@ -28,7 +28,6 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
                     "cli-topology:password": "cisco",
                     "cli-topology:journal-size": 150,
                     "cli-topology:dry-run-journal-size": 150,
-                    "node-extension:reconcile": false,
                     "uniconfig-config:install-uniconfig-node-enabled": true
                 }
             },
@@ -44,8 +43,7 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
                     "cli-topology:password": "cisco",
                     "cli-topology:dry-run-journal-size": 180,
                     "cli-topology:journal-size": 150,
-                    "uniconfig-config:install-uniconfig-node-enabled": true,
-                    "node-extension:reconcile": false
+                    "uniconfig-config:install-uniconfig-node-enabled": true
                 }
             }
         ]
@@ -94,8 +92,7 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
                     "cli-topology:password": "cisco",
                     "cli-topology:dry-run-journal-size": 180,
                     "cli-topology:journal-size": 150,
-                    "uniconfig-config:install-uniconfig-node-enabled": false,
-                    "node-extension:reconcile": false
+                    "uniconfig-config:install-uniconfig-node-enabled": false
                 },
                 "netconf": {
                     "netconf-node-topology:host": "192.168.1.211",
@@ -122,9 +119,7 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
                     "cli-topology:username": "cisco",
                     "cli-topology:password": "cisco",
                     "cli-topology:journal-size": 150,
-                    "cli-topology:dry-run-journal-size": 150,
-                    "node-extension:reconcile": false
-
+                    "cli-topology:dry-run-journal-size": 150
                 }
             }
         ]
@@ -173,7 +168,6 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
                     "cli-topology:password": "cisco",
                     "cli-topology:journal-size": 150,
                     "cli-topology:dry-run-journal-size": 150,
-                    "node-extension:reconcile": false,
                     "uniconfig-config:install-uniconfig-node-enabled": true
                 }
             },
@@ -189,8 +183,7 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
                     "cli-topology:password": "cisco",
                     "cli-topology:dry-run-journal-size": 180,
                     "cli-topology:journal-size": 150,
-                    "uniconfig-config:install-uniconfig-node-enabled": true,
-                    "node-extension:reconcile": false
+                    "uniconfig-config:install-uniconfig-node-enabled": true
                 }
             }
         ]
@@ -241,7 +234,6 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
                     "cli-topology:password": "cisco",
                     "cli-topology:journal-size": 150,
                     "cli-topology:dry-run-journal-size": 150,
-                    "node-extension:reconcile": false,
                     "uniconfig-config:install-uniconfig-node-enabled": true
                 }
             },
@@ -257,8 +249,7 @@ curl --location --request POST 'http://localhost:8181/rests/operations/connectio
                     "cli-topology:password": "cisco",
                     "cli-topology:dry-run-journal-size": 180,
                     "cli-topology:journal-size": 150,
-                    "uniconfig-config:install-uniconfig-node-enabled": true,
-                    "node-extension:reconcile": false
+                    "uniconfig-config:install-uniconfig-node-enabled": true
                 }
             }
         ]


### PR DESCRIPTION
Reasons - Cache was removed from southbound layer - syncing is
done only from uniconfig layer.
