### PR TITLE
Fix escaping of identifiers in examples

### DIFF
--- a/frinx-uniconfig/translation-units-docs/README.md
+++ b/frinx-uniconfig/translation-units-docs/README.md
@@ -150,7 +150,7 @@ GET operation can be issued on both config/operational datastore. Config datasto
 Example of a case where the information is not the same (the only difference in requests is config vs operational):
 
 ```
-GET http://{{odl_ip}}:8181/rests/data/network-topology:network-topology/topology=cli/node={{node_id}}/yang-ext:mount/frinx-openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=frinx-openconfig-policy-types:STATIC,default/static-routes/static=10.255.1.0%2F24?content=config
+GET http://{{odl_ip}}:8181/rests/data/network-topology:network-topology/topology=cli/node={{node_id}}/yang-ext:mount/frinx-openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=frinx-openconfig-policy-types:STATIC,default/static-routes/static=%2210.255.1.0/24%22?content=config
 ```
 ```json
 {
@@ -176,7 +176,7 @@ GET http://{{odl_ip}}:8181/rests/data/network-topology:network-topology/topology
 ```
 
 ```
-GET http://{{odl_ip}}:8181/rests/data/network-topology:network-topology/topology=cli/node={{node_id}}/yang-ext:mount/frinx-openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=frinx-openconfig-policy-types:STATIC,default/static-routes/static=10.255.1.0%2F24?content=nonconfig
+GET http://{{odl_ip}}:8181/rests/data/network-topology:network-topology/topology=cli/node={{node_id}}/yang-ext:mount/frinx-openconfig-network-instance:network-instances/network-instance=default/protocols/protocol=frinx-openconfig-policy-types:STATIC,default/static-routes/static=%2210.255.1.0/24%22?content=nonconfig
 ```
 
 ```json

--- a/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_netconf/junos.md
+++ b/frinx-uniconfig/user-guide/network-management-protocols/uniconfig_netconf/junos.md
@@ -121,7 +121,7 @@ To show the configuration related to a specific interface, in this case
 
 ```bash
 curl -X GET \
- http://localhost:8181/rests/data/network-topology:network-topology/topology=uniconfig/node=junos/frinx-uniconfig-topology:configuration/configuration:configuration/interfaces/interface=ge-0%2F0%2F2?content=config
+ http://localhost:8181/rests/data/network-topology:network-topology/topology=uniconfig/node=junos/frinx-uniconfig-topology:configuration/configuration:configuration/interfaces/interface=%22ge-0/0/2%22?content=config
 ```
 
 The response will show the status of the interface:
@@ -144,7 +144,7 @@ To enable the interface “ge-0/0/2” in config datastore, run:
 
 ```bash
 curl -X PUT \
- http://localhost:8181/rests/data/network-topology:network-topology/topology=uniconfig/node=junos/frinx-uniconfig-topology:configuration/configuration:configuration/interfaces/interface=ge-0%2F0%2F2 \
+ http://localhost:8181/rests/data/network-topology:network-topology/topology=uniconfig/node=junos/frinx-uniconfig-topology:configuration/configuration:configuration/interfaces/interface=%22ge-0/0/2%22 \
  -d '{
    "interface": [
        {
@@ -160,7 +160,7 @@ To disable the interface “ge-0/0/2” in config datastore, run:
 
 ```bash
 curl -X PUT \
- http://localhost:8181/rests/data/network-topology:network-topology/topology=uniconfig/node=junos/frinx-uniconfig-topology:configuration/configuration:configuration/interfaces/interface=ge-0%2F0%2F2 \
+ http://localhost:8181/rests/data/network-topology:network-topology/topology=uniconfig/node=junos/frinx-uniconfig-topology:configuration/configuration:configuration/interfaces/interface=%22ge-0/0/2%22 \
  -d '{
    "interface": [
        {

--- a/frinx-uniconfig/user-guide/uniconfig-operations/jsonb-filtering/database-jsonb-filtering/readme.md
+++ b/frinx-uniconfig/user-guide/uniconfig-operations/jsonb-filtering/database-jsonb-filtering/readme.md
@@ -130,5 +130,5 @@ reason, it is necessary to wrap this key into wrapping symbols
 %28%23GigabitEthernet0/0/0/2%29.
 
 ```
-http://localhost:8181/rests/data/network-topology:network-topology/topology=uniconfig/node=IOSXR/configuration/frinx-openconfig-interfaces:interfaces/interface=GigabitEthernet0%2F0%2F0%2F2?jsonb-filter={$/frinx-openconfig-interfaces:interfaces/interface=%28%23GigabitEthernet0/0/0/2%29/config/enabled}==false&content=nonconfig
+http://localhost:8181/rests/data/network-topology:network-topology/topology=uniconfig/node=IOSXR/configuration/frinx-openconfig-interfaces:interfaces/interface=%22GigabitEthernet0/0/0/2%22?jsonb-filter={$/frinx-openconfig-interfaces:interfaces/interface=%28%23GigabitEthernet0/0/0/2%29/config/enabled}==false&content=nonconfig
 ```

--- a/frinx-uniconfig/user-guide/uniconfig-operations/restconf/readme.md
+++ b/frinx-uniconfig/user-guide/uniconfig-operations/restconf/readme.md
@@ -51,9 +51,9 @@ list, there must be defined ordered keys of the list behind the data
 node name, for example, \<nodeName\>=\<valueOfKey1\>,\<valueOfKey2\>. ..
 
 !!!
-The following example shows how reserved characters are percent-encoded within a key value. The value of "key1" contains a comma, single-quote, double-quote, colon, double-quote, space, and forward slash (,'":" /). Note that double-quote is not a reserved character and does not need to be percent-encoded. The value of "key2" is the empty string, and the value of "key3" is the string "foo". 
+The following example shows how reserved characters are percent-encoded within a key value. The value of "key1" contains a comma, single-quote, double-quote, colon, double-quote, and space (,'":" ). Note that double-quote is not a reserved character and does not need to be percent-encoded. The value of "key2" is the empty string, and the value of "key3" is the string "foo". 
 
-Example URL: /rests/data/example-top:top/list1=%2C%27"%3A"%20%2F,,foo
+Example URL: /rests/data/example-top:top/list1=%2C%27"%3A"%20,,foo
 !!!
 
 - The format \<moduleName\>:\<nodeName\> has to be used in this case

--- a/frinx-uniconfig/user-guide/uniconfig-operations/templates-manager/readme.md
+++ b/frinx-uniconfig/user-guide/uniconfig-operations/templates-manager/readme.md
@@ -494,7 +494,7 @@ Reading specific subtree under 'interface\_template' - unit with name
 'eth-0/{\$interface-id}'.
 
 ```bash RPC Request
-curl --location --request GET 'http://localhost:8181/rests/data/network-topology:network-topology/topology=templates/node=interface_template/frinx-uniconfig-topology:configuration/interfaces:interfaces=eth-0%2F%7B%24interface-id%7D/unit=%7B%24unit-id%7D?content=config' \
+curl --location --request GET 'http://localhost:8181/rests/data/network-topology:network-topology/topology=templates/node=interface_template/frinx-uniconfig-topology:configuration/interfaces:interfaces=%22eth-0/{$interface-id}%22/unit=%7B%24unit-id%7D?content=config' \
 --header 'Accept: application/json'
 ```
 
@@ -527,7 +527,7 @@ Changing 'update' tag of the 'address' list entry to 'create' tag using
 PLAIN-PATCH RESTCONF method.
 
 ```bash RPC Request
-curl --location --request PUT 'http://localhost:8181/rests/data/network-topology:network-topology/topology=templates/node=interface_template/frinx-uniconfig-topology:configuration/interfaces:interfaces=eth-0%2F%7B%24interface-id%7D/unit=%7B%24unit-id%7D/family-inet/address=%7B%24ip-address%7D' \
+curl --location --request PUT 'http://localhost:8181/rests/data/network-topology:network-topology/topology=templates/node=interface_template/frinx-uniconfig-topology:configuration/interfaces:interfaces=%22eth-0/{$interface-id}%22/unit=%7B%24unit-id%7D/family-inet/address=%7B%24ip-address%7D' \
 --header 'Accept: application/json' \
 --header 'Content-Type: application/json' \
 --data-raw '{


### PR DESCRIPTION
- adjusted to changes after 7.0.x

Signed-off-by: Peter Puškár <peter.puskar@elisapolystar.com>
